### PR TITLE
fix: redirect malformed /signup&… URLs to /signup?… (preserve UTM; fixes #580)

### DIFF
--- a/ladderly-io/src/middleware.ts
+++ b/ladderly-io/src/middleware.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Routes we allow this auto-fix on.
+ * Keep this list tight so we don't accidentally rewrite unrelated paths.
+ * Add additional entries here if other pages are observed with the same issue.
+ */
+const FIXABLE = [
+  "/signup",
+  "/signup/interview-prep",
+  "/signup/research-backed",
+  "/signup/technical-prep",
+  "/signup/wellness",
+] as const;
+
+export function middleware(req: NextRequest) {
+  const p = req.nextUrl.pathname;
+
+  for (const base of FIXABLE) {
+    const bad1 = base + "&";
+    const bad2 = base + "%26"; // encoded &
+    if (p.startsWith(bad1) || p.startsWith(bad2)) {
+      const rest = p.slice((p.startsWith(bad1) ? bad1 : bad2).length);
+      const to = req.nextUrl.clone();
+      to.pathname = base;
+      to.search = rest ? `?${rest}` : "";
+      return NextResponse.redirect(to, 308);
+    }
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)"],
+};


### PR DESCRIPTION
**Problem**
Some external links use `/signup&...` (ampersand in the path) instead of starting the query with `?`. Next.js treats `&` in the pathname as part of the route, which 404s before the signup page runs.

**Change**
Add `src/middleware.ts` to intercept malformed paths and 308-redirect:
- `/signup&foo=bar`  →  `/signup?foo=bar`
- Also handles encoded ampersand: `/signup%26foo=bar`

Scoped to signup routes only; preserves all UTM parameters.

**Scope / Risk**
- 1 file, route-level redirect only.
- No changes to page components or server logic.

**Testing**
- Local dev: verified `http://localhost:3000/signup&utm_source=youtube_main` 308-redirects to `/signup?utm_source=youtube_main`.
- Normal `/signup` still renders.
- Previous test suite run: 65 passing tests (no code paths affected).

**Notes**
External sources (e.g., YouTube description) may contain the old `/signup&...` link. This redirect is a safety net; updating external links to `?utm_source=...` is still recommended.

Fixes #580.