### PR TITLE
fix: #573 subsets are backtracking but not labeled as such

### DIFF
--- a/ladderly-io/src/app/leetcode-tool/LeetCodeList.tsx
+++ b/ladderly-io/src/app/leetcode-tool/LeetCodeList.tsx
@@ -120,11 +120,21 @@ export function LeetCodeList() {
 
   // Filter by pattern tag if selected
   if (patternFilters.length > 0) {
-    const requiredTags = patternFilters.map((p) => `pattern:${p}`)
-    filteredItems = filteredItems.filter((item) =>
-      item.checklistItem.tags.some((tag) => requiredTags.includes(tag)),
+    const requiredPatterns = patternFilters.map((p) =>
+      p.trim().toLowerCase(),
     )
+
+    filteredItems = filteredItems.filter((item) => {
+      // collect pattern tags for this item
+      const itemPatterns = item.checklistItem.tags
+        .filter((tag) => tag.startsWith('pattern:'))
+        .map((tag) => tag.slice('pattern:'.length).trim().toLowerCase())
+
+      // show the item if it has at least one of the selected patterns
+      return requiredPatterns.some((pattern) => itemPatterns.includes(pattern))
+    })
   }
+
 
   // Filter by difficulty tag if selected
   if (difficultyFilter && difficultyFilter !== 'All Difficulties') {


### PR DESCRIPTION
This PR resolves #573 by correcting how the LeetCode tool filters items by pattern tags.

Previously, the pattern filter did not properly detect pattern: tags on checklist items, causing “Subsets” to be excluded from the Backtracking filter even though it had the tag pattern:Backtracking.

The update ensures:

Pattern tags are extracted using tag.startsWith('pattern:')

Filters compare normalized pattern values

Items with matching pattern tags (e.g., “Subsets”) now correctly appear when filtering by Backtracking

No other behavior was changed.