### PR TITLE
Refactor AI instructions to Cursor rules (.cursor/rules/)

### DIFF
--- a/.cursor/rules/auth-session-preference.mdc
+++ b/.cursor/rules/auth-session-preference.mdc
@@ -1,0 +1,13 @@
+---
+description: Prefer getServerAuthSession on server over useSession on client
+globs:
+  - "ladderly-io/src/app/**/*.tsx"
+  - "ladderly-io/src/server/**/*.ts"
+alwaysApply: false
+---
+
+# Auth session preference
+
+Prefer `getServerAuthSession` on server components over using `useSession` on client components where possible.
+
+Use server-side session in Server Components and API/server code; reserve `useSession` for client components when session is needed in the browser.

--- a/.cursor/rules/ladderly-project-context.mdc
+++ b/.cursor/rules/ladderly-project-context.mdc
@@ -1,0 +1,20 @@
+---
+description: Ladderly.io web project context and agent role
+alwaysApply: true
+---
+
+# Ladderly.io project context
+
+Act as an expert web developer for the **Ladderly.io** web project.
+
+## Where to get context
+
+- **Dependencies**: See `@ladderly-io/package.json`
+- **Data model**: See `@ladderly-io/prisma/schema.prisma`
+- **Repo layout**: The app lives under `ladderly-io/` (src, prisma, tests, scripts, etc.)
+
+Do not copy package.json or folder structure into rules or prompts; reference these files when needed.
+
+## Behavior
+
+After reading the relevant context for the current task, ask any clarifying questions. If you have no questions, state that you have read the high-level context and are ready to help with the concern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AI Assistant Instructions
 
+> **Deprecated for Cursor:** Project rules and context have moved to **`.cursor/rules/`** at the repo root. Cursor uses those rules automatically. This file is kept for reference only.
+
+---
+
 Act as an expert web developer to help me resolve a concern.
 We are working on the Ladderly.io web project and I will describe the dependencies for the project,
 the folder structure, and the data model. Once you have read through these materials, ask any clarifying

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+Project rules and context: see `.cursor/rules/` at the repo root.

--- a/ladderly-io/scripts/python/copilot-instructions.txt
+++ b/ladderly-io/scripts/python/copilot-instructions.txt
@@ -1,8 +1,13 @@
-Act as an expert web developer to help me resolve a concern. 
-We are working on the Ladderly.io web project and I will describe the dependencies for the project, 
-the folder structure, and the data model. Once you have read through these materials, ask any clarifying 
+DEPRECATED: AI/agent instructions have moved to the repo root .cursor/rules/ directory.
+Cursor uses those rules automatically. This file is kept for reference only.
+
+================================================================================
+
+Act as an expert web developer to help me resolve a concern.
+We are working on the Ladderly.io web project and I will describe the dependencies for the project,
+the folder structure, and the data model. Once you have read through these materials, ask any clarifying
 questions that you have.
-If you have no questions, state that you have read through the high-level context 
+If you have no questions, state that you have read through the high-level context
 and you are ready to help with the current concern.
 
 


### PR DESCRIPTION
## Summary
Moves project and auth instructions from AGENTS.md and `ladderly-io/scripts/python/copilot-instructions.txt` into Cursor’s rule format under `.cursor/rules/`, and adds deprecation notices to the old files.

## Changes
- **Add** `.cursor/rules/ladderly-project-context.mdc` – project context and agent role; references `@ladderly-io/package.json` and `@ladderly-io/prisma/schema.prisma`; `alwaysApply: true`.
- **Add** `.cursor/rules/auth-session-preference.mdc` – prefer `getServerAuthSession` on server over `useSession` on client; applies only when editing `ladderly-io/src/app/**/*.tsx` or `ladderly-io/src/server/**/*.ts`.
- **Update** `AGENTS.md` – add deprecation notice at top; file kept for reference.
- **Update** `ladderly-io/scripts/python/copilot-instructions.txt` – add deprecation notice at top; file kept for reference.
- **Update** `CLAUDE.md` – point to `.cursor/rules/` instead of `@AGENTS.md`.

- Aligns with Cursor’s rules docs: (https://cursor.com/docs/context/rules)  reference files instead of inlining package.json/folder structure.
- Single source of truth for Cursor in `.cursor/rules/`; old files remain for reference only.